### PR TITLE
fix(#423): paginate likes, correct artist fallback, honest completion log

### DIFF
--- a/API.md
+++ b/API.md
@@ -139,6 +139,8 @@ interface Track {
     transcodings: Array<{
       /** URL to fetch audio data */
       url: string;
+      /** True for Go+ preview/snippet transcodings; false for full streams */
+      snipped?: boolean;
       /** Format details */
       format: {
         /** Streaming protocol (e.g., 'progressive') */

--- a/API.md
+++ b/API.md
@@ -126,7 +126,7 @@ interface Track {
   id: number;
   /** Track title */
   title: string;
-  /** Uploading user (canonical fallback for the track artist) */
+  /** Uploading user */
   user: {
     /** Username of the uploader */
     username: string;
@@ -148,7 +148,7 @@ interface Track {
       };
     }>;
   };
-  /** Additional metadata from publisher (fields may be missing on individual tracks) */
+  /** Additional metadata from publisher */
   publisher_metadata?: {
     /** Artist name from publisher */
     artist?: string;

--- a/API.md
+++ b/API.md
@@ -61,14 +61,13 @@ Gets the SoundCloud client information needed for API requests.
 function getClient(profileName: string): Promise<Client>
 ```
 
-#### getUserLikes(client, offset?, limit?)
+#### getUserLikes(client, limit?)
 
-Fetches liked tracks for a SoundCloud user.
+Fetches liked tracks for a SoundCloud user, paginating internally via SoundCloud's `next_href` cursor until `limit` is reached.
 
 ```typescript
 function getUserLikes(
   client: Client,
-  offset?: string,
   limit?: number,
 ): Promise<UserLike[]>
 ```
@@ -127,8 +126,11 @@ interface Track {
   id: number;
   /** Track title */
   title: string;
-  /** Track artist */
-  artist: string;
+  /** Uploading user (canonical fallback for the track artist) */
+  user: {
+    /** Username of the uploader */
+    username: string;
+  };
   /** URL to track artwork */
   artwork_url?: string;
   /** Media transcoding information */
@@ -146,12 +148,12 @@ interface Track {
       };
     }>;
   };
-  /** Additional metadata from publisher */
+  /** Additional metadata from publisher (fields may be missing on individual tracks) */
   publisher_metadata?: {
     /** Artist name from publisher */
-    artist: string;
+    artist?: string;
     /** Release title from publisher */
-    release_title: string;
+    release_title?: string;
   };
 }
 
@@ -232,7 +234,7 @@ await soundCloudSync({
 import { getClient, getUserLikes, getMissingMusic, verifyTimestamps } from 'soundcloud-sync';
 
 const client = await getClient('your-username');
-const likes = await getUserLikes(client, '0', 100);
+const likes = await getUserLikes(client, 100);
 
 // Define callbacks for progress tracking
 const callbacks = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export default async function soundCloudSync({
 
   try {
     const client = await getClient(username);
-    const userLikes = await getUserLikes(client, '0', limit);
+    const userLikes = await getUserLikes(client, limit);
 
     const callbacks = {
       onDownloadStart: (track: Track) => logger.info(`Downloading "${track.title}"`),
@@ -48,16 +48,19 @@ export default async function soundCloudSync({
       ({ length: verifyResultsLength } = await verifyTimestamps(userLikes, folder, callbacks));
     }
 
-    let downloadResultsLength = 0;
+    let downloadedCount = 0;
+    let failedCount = 0;
     if (!noDownload) {
-      ({ length: downloadResultsLength } = await getMissingMusic(userLikes, folder, callbacks));
+      const results = await getMissingMusic(userLikes, folder, callbacks);
+      downloadedCount = results.filter(r => r.status.success).length;
+      failedCount = results.length - downloadedCount;
     }
 
-    logger.info(
-      `Completed successfully${downloadResultsLength ? `: ${downloadResultsLength} tracks downloaded` : ''}${
-        shouldVerifyTimestamps ? `, ${verifyResultsLength} tracks verified` : ''
-      }`,
-    );
+    const parts: string[] = [];
+    if (!noDownload) parts.push(`${downloadedCount} downloaded`);
+    if (failedCount) parts.push(`${failedCount} failed`);
+    if (shouldVerifyTimestamps) parts.push(`${verifyResultsLength} verified`);
+    logger.info(`Completed${parts.length ? `: ${parts.join(', ')}` : ''}`);
   } catch (error) {
     logger.error(`An error occurred: ${error instanceof Error ? error.message : String(error)}`);
     throw error;

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,9 +57,9 @@ export default async function soundCloudSync({
     }
 
     const parts: string[] = [];
-    if (!noDownload) parts.push(`${downloadedCount} downloaded`);
+    if (downloadedCount) parts.push(`${downloadedCount} downloaded`);
     if (failedCount) parts.push(`${failedCount} failed`);
-    if (shouldVerifyTimestamps) parts.push(`${verifyResultsLength} verified`);
+    if (verifyResultsLength) parts.push(`${verifyResultsLength} verified`);
     logger.info(`Completed${parts.length ? `: ${parts.join(', ')}` : ''}`);
   } catch (error) {
     logger.error(`An error occurred: ${error instanceof Error ? error.message : String(error)}`);

--- a/src/services/getMissingMusic.ts
+++ b/src/services/getMissingMusic.ts
@@ -5,21 +5,20 @@ import sanitiseFilename from '../helpers/sanitise.ts';
 import webAgent from './webAgent.ts';
 import { UserLike, Callbacks, DownloadResult, Track } from '../types.ts';
 
+/** Max simultaneous in-flight downloads — bounds local fd/memory pressure. */
+const MAX_CONCURRENT_DOWNLOADS = 128;
+
 const getBestTranscoding = (track: Track) =>
-  track.media.transcodings.find(
-    t =>
-      (t.format.protocol === 'progressive' && t.format.mime_type === 'audio/mpeg') ||
-      t.format.mime_type === 'audio/mpeg',
-  );
+  track.media.transcodings.find(t => t.format.mime_type === 'audio/mpeg');
 
 export const getTrackTitle = (track: Track) =>
   track?.publisher_metadata?.release_title || track.title;
 
-export const getTrackArtist = (track: Track) => track?.publisher_metadata?.artist || track.artist;
+export const getTrackArtist = (track: Track) =>
+  track?.publisher_metadata?.artist || track.user.username;
 
 const getArtworkUrl = (url?: string) => url?.replace('large', 't500x500');
 
-// Download a single segment
 const downloadSegment = async (url: string): Promise<Uint8Array> => {
   const response = await fetch(url);
   if (!response.ok) throw new Error(`Failed to download segment: ${url}`);
@@ -27,7 +26,6 @@ const downloadSegment = async (url: string): Promise<Uint8Array> => {
   return new Uint8Array(buffer);
 };
 
-// Download artwork if available
 const downloadArtwork = async (url: string): Promise<ArrayBuffer | null> => {
   try {
     const response = await fetch(url);
@@ -53,88 +51,93 @@ export default async function getMissingMusic(
     path.parse(filename).name.toLowerCase(),
   );
 
-  // Handle missing tracks in parallel
   const missingTracks = likes.filter(
-    ({ track }) =>
-      !availableMusic.includes(sanitiseFilename(track.title).toLowerCase()) &&
-      track.media.transcodings.length > 0,
+    ({ track }) => !availableMusic.includes(sanitiseFilename(track.title).toLowerCase()),
   );
 
-  return Promise.all(
-    missingTracks.map(async ({ track, created_at }) => {
-      callbacks.onDownloadStart?.(track);
+  const downloadOne = async ({ track, created_at }: UserLike): Promise<DownloadResult> => {
+    callbacks.onDownloadStart?.(track);
 
-      try {
-        const transcoding = getBestTranscoding(track);
-        if (!transcoding) {
-          throw new Error('No suitable audio format found');
-        }
+    try {
+      const transcoding = getBestTranscoding(track);
+      if (!transcoding) throw new Error('No suitable audio format');
+      // SoundCloud serves Go+ snippet-only tracks under `/preview/`; full streams under `/stream/`
+      if (transcoding.url.includes('/preview/')) throw new Error('Snippet-only stream');
 
-        const transcodingResponse = await webAgent(transcoding.url);
-        const { url: playlistUrl } = JSON.parse(transcodingResponse as string);
+      const transcodingResponse = await webAgent(transcoding.url);
+      const { url: playlistUrl } = JSON.parse(transcodingResponse as string);
+      if (!playlistUrl) throw new Error('Stream URL unavailable');
 
-        // Get playlist
-        const playlistResponse = await fetch(playlistUrl);
-        if (!playlistResponse.ok) throw new Error('Failed to fetch playlist');
-        const playlist = await playlistResponse.text();
+      const playlistResponse = await fetch(playlistUrl);
+      if (!playlistResponse.ok) throw new Error('Failed to fetch playlist');
+      const playlist = await playlistResponse.text();
 
-        // Parse playlist for MP3 segments
-        const segments = playlist
-          .split('\n')
-          .filter(line => line.trim() && !line.startsWith('#'))
-          .map(line => new URL(line, playlistUrl).toString());
+      const segments = playlist
+        .split('\n')
+        .filter(line => line.trim() && !line.startsWith('#'))
+        .map(line => new URL(line, playlistUrl).toString());
 
-        if (segments.length === 0) {
-          throw new Error('No audio segments found in playlist');
-        }
-
-        // Download and concatenate segments
-        const chunks = await Promise.all(segments.map(downloadSegment));
-
-        // Combine all chunks
-        const totalLength = chunks.reduce((acc, chunk) => acc + chunk.length, 0);
-        const audioBuffer = new Uint8Array(totalLength);
-        let offset = 0;
-        for (const chunk of chunks) {
-          audioBuffer.set(chunk, offset);
-          offset += chunk.length;
-        }
-
-        // Add ID3 tags
-        const writer = new ID3Writer(audioBuffer.buffer);
-        writer.setFrame('TIT2', getTrackTitle(track)).setFrame('TPE1', [getTrackArtist(track)]);
-
-        // Add artwork if available
-        if (track.artwork_url) {
-          const artworkBuffer = await downloadArtwork(getArtworkUrl(track.artwork_url)!);
-          if (artworkBuffer) {
-            writer.setFrame('APIC', {
-              type: 3,
-              data: artworkBuffer,
-              description: '',
-            });
-          }
-        }
-
-        // Write file with tags
-        const filePath = path.join(folder, `${sanitiseFilename(track.title)}.mp3`);
-        const taggedBuffer = new Uint8Array(writer.addTag());
-        await fs.writeFile(filePath, taggedBuffer);
-        const timestamp = new Date(created_at);
-        await fs.utimes(filePath, timestamp, timestamp);
-
-        callbacks.onDownloadComplete?.(track);
-        return { track: track.title, status: { success: true } };
-      } catch (error) {
-        callbacks.onDownloadError?.(track, error);
-        return {
-          track: track.title,
-          status: {
-            success: false,
-            error: error instanceof Error ? error.message : String(error),
-          },
-        };
+      if (segments.length === 0) {
+        throw new Error('No audio segments found in playlist');
       }
-    }),
+
+      const chunks = await Promise.all(segments.map(downloadSegment));
+
+      const totalLength = chunks.reduce((acc, chunk) => acc + chunk.length, 0);
+      const audioBuffer = new Uint8Array(totalLength);
+      let offset = 0;
+      for (const chunk of chunks) {
+        audioBuffer.set(chunk, offset);
+        offset += chunk.length;
+      }
+
+      const writer = new ID3Writer(audioBuffer.buffer);
+      writer.setFrame('TIT2', getTrackTitle(track)).setFrame('TPE1', [getTrackArtist(track)]);
+
+      if (track.artwork_url) {
+        const artworkBuffer = await downloadArtwork(getArtworkUrl(track.artwork_url)!);
+        if (artworkBuffer) {
+          writer.setFrame('APIC', {
+            type: 3,
+            data: artworkBuffer,
+            description: '',
+          });
+        }
+      }
+
+      const filePath = path.join(folder, `${sanitiseFilename(track.title)}.mp3`);
+      const taggedBuffer = new Uint8Array(writer.addTag());
+      await fs.writeFile(filePath, taggedBuffer);
+      const timestamp = new Date(created_at);
+      await fs.utimes(filePath, timestamp, timestamp);
+
+      callbacks.onDownloadComplete?.(track);
+      return { track: track.title, status: { success: true } };
+    } catch (error) {
+      callbacks.onDownloadError?.(track, error);
+      return {
+        track: track.title,
+        status: {
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      };
+    }
+  };
+
+  // Bounded worker pool: keep up to MAX_CONCURRENT_DOWNLOADS in-flight; parallelism comes from running multiple workers
+  const results: DownloadResult[] = new Array(missingTracks.length);
+  let nextIndex = 0;
+  const worker = async (): Promise<void> => {
+    while (nextIndex < missingTracks.length) {
+      const i = nextIndex;
+      nextIndex += 1;
+      // eslint-disable-next-line no-await-in-loop
+      results[i] = await downloadOne(missingTracks[i]);
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(MAX_CONCURRENT_DOWNLOADS, missingTracks.length) }, worker),
   );
+  return results;
 }

--- a/src/services/getMissingMusic.ts
+++ b/src/services/getMissingMusic.ts
@@ -5,11 +5,12 @@ import sanitiseFilename from '../helpers/sanitise.ts';
 import webAgent from './webAgent.ts';
 import { UserLike, Callbacks, DownloadResult, Track } from '../types.ts';
 
-/** Max simultaneous in-flight downloads — bounds local fd/memory pressure. */
 const MAX_CONCURRENT_DOWNLOADS = 128;
 
 const getBestTranscoding = (track: Track) =>
-  track.media.transcodings.find(t => t.format.mime_type === 'audio/mpeg');
+  track.media.transcodings.find(
+    t => t.format.mime_type === 'audio/mpeg' && !t.url.includes('/preview/'),
+  ) ?? track.media.transcodings.find(t => t.format.mime_type === 'audio/mpeg');
 
 export const getTrackTitle = (track: Track) =>
   track?.publisher_metadata?.release_title || track.title;
@@ -60,13 +61,11 @@ export default async function getMissingMusic(
 
     try {
       const transcoding = getBestTranscoding(track);
-      if (!transcoding) throw new Error('No suitable audio format');
-      // SoundCloud serves Go+ snippet-only tracks under `/preview/`; full streams under `/stream/`
-      if (transcoding.url.includes('/preview/')) throw new Error('Snippet-only stream');
+      if (!transcoding) throw new Error('No suitable audio format found');
+      if (transcoding.url.includes('/preview/')) throw new Error('No full-length audio available');
 
       const transcodingResponse = await webAgent(transcoding.url);
       const { url: playlistUrl } = JSON.parse(transcodingResponse as string);
-      if (!playlistUrl) throw new Error('Stream URL unavailable');
 
       const playlistResponse = await fetch(playlistUrl);
       if (!playlistResponse.ok) throw new Error('Failed to fetch playlist');
@@ -125,7 +124,6 @@ export default async function getMissingMusic(
     }
   };
 
-  // Bounded worker pool: keep up to MAX_CONCURRENT_DOWNLOADS in-flight; parallelism comes from running multiple workers
   const results: DownloadResult[] = new Array(missingTracks.length);
   let nextIndex = 0;
   const worker = async (): Promise<void> => {

--- a/src/services/getMissingMusic.ts
+++ b/src/services/getMissingMusic.ts
@@ -8,9 +8,8 @@ import { UserLike, Callbacks, DownloadResult, Track } from '../types.ts';
 const MAX_CONCURRENT_DOWNLOADS = 128;
 
 const getBestTranscoding = (track: Track) =>
-  track.media.transcodings.find(
-    t => t.format.mime_type === 'audio/mpeg' && !t.url.includes('/preview/'),
-  ) ?? track.media.transcodings.find(t => t.format.mime_type === 'audio/mpeg');
+  track.media.transcodings.find(t => t.format.mime_type === 'audio/mpeg' && !t.snipped) ??
+  track.media.transcodings.find(t => t.format.mime_type === 'audio/mpeg');
 
 export const getTrackTitle = (track: Track) =>
   track?.publisher_metadata?.release_title || track.title;
@@ -62,7 +61,7 @@ export default async function getMissingMusic(
     try {
       const transcoding = getBestTranscoding(track);
       if (!transcoding) throw new Error('No suitable audio format found');
-      if (transcoding.url.includes('/preview/')) throw new Error('No full-length audio available');
+      if (transcoding.snipped) throw new Error('No full-length audio available');
 
       const transcodingResponse = await webAgent(transcoding.url);
       const { url: playlistUrl } = JSON.parse(transcodingResponse as string);

--- a/src/services/getUserLikes.ts
+++ b/src/services/getUserLikes.ts
@@ -2,7 +2,6 @@ import webAgent from './webAgent.ts';
 import { Client, UserLike } from '../types.ts';
 import logger from '../helpers/logger.ts';
 
-/** Maximum tracks SoundCloud's API returns per request, regardless of `limit`. */
 const PAGE_SIZE = 200;
 
 /**
@@ -30,7 +29,6 @@ export default async function getUserLikes(client: Client, limit = 50): Promise<
   while (nextHref && collection.length < limit) {
     logger.debug('Fetching user likes page', { fetched: collection.length, limit });
 
-    // Cursor pagination is inherently sequential — each page's `next_href` is in the previous response
     // eslint-disable-next-line no-await-in-loop
     const response = await webAgent(`${nextHref}&${auth}`);
     const page = JSON.parse(response as string) as {
@@ -40,11 +38,7 @@ export default async function getUserLikes(client: Client, limit = 50): Promise<
 
     collection.push(...page.collection);
     nextHref = page.next_href ?? null;
-
-    if (page.collection.length === 0) break;
   }
-
-  logger.debug('User likes fetched', { count: Math.min(collection.length, limit) });
 
   return collection.slice(0, limit).map(({ track, created_at }) => ({
     created_at,

--- a/src/services/getUserLikes.ts
+++ b/src/services/getUserLikes.ts
@@ -7,9 +7,10 @@ const PAGE_SIZE = 200;
 /**
  * Fetches a user's liked tracks from SoundCloud.
  *
- * Walks SoundCloud's cursor-paginated `track_likes` endpoint via `next_href`
- * until either `limit` is reached or there are no more pages, then attaches
- * authentication to each track's media URLs for streaming.
+ * The function:
+ * 1. Constructs the initial paginated API request URL
+ * 2. Walks `next_href` cursor until `limit` is reached or pages are exhausted
+ * 3. Attaches authentication to each track's media URLs for streaming
  *
  * @param client - SoundCloud client details for authentication
  * @param limit - Maximum number of likes to fetch (default: 50)

--- a/src/services/getUserLikes.ts
+++ b/src/services/getUserLikes.ts
@@ -2,36 +2,51 @@ import webAgent from './webAgent.ts';
 import { Client, UserLike } from '../types.ts';
 import logger from '../helpers/logger.ts';
 
+/** Maximum tracks SoundCloud's API returns per request, regardless of `limit`. */
+const PAGE_SIZE = 200;
+
 /**
  * Fetches a user's liked tracks from SoundCloud.
  *
- * The function:
- * 1. Constructs an authenticated API request URL
- * 2. Fetches the liked tracks data
- * 3. Adds authentication to media URLs for streaming
+ * Walks SoundCloud's cursor-paginated `track_likes` endpoint via `next_href`
+ * until either `limit` is reached or there are no more pages, then attaches
+ * authentication to each track's media URLs for streaming.
  *
  * @param client - SoundCloud client details for authentication
- * @param offset - Pagination offset for fetching likes (default: '')
- * @param limit - Number of likes to fetch (default: 50)
+ * @param limit - Maximum number of likes to fetch (default: 50)
  * @returns Array of liked tracks with authenticated media URLs
  * @throws Error if the API request fails or returns invalid data
  */
-export default async function getUserLikes(
-  client: Client,
-  offset = '',
-  limit = 50,
-): Promise<UserLike[]> {
+export default async function getUserLikes(client: Client, limit = 50): Promise<UserLike[]> {
   const auth = `client_id=${client.id}&app_version=${client.version}&app_locale=en`;
-  logger.debug('Fetching user likes', { offset, limit });
+  const collection: UserLike[] = [];
 
-  const response = await webAgent(
-    `https://api-v2.soundcloud.com/users/${client.urn}/track_likes?offset=${offset}&limit=${limit}&${auth}`,
-  );
+  let nextHref: string | null =
+    `https://api-v2.soundcloud.com/users/${client.urn}/track_likes?offset=0&limit=${Math.min(
+      limit,
+      PAGE_SIZE,
+    )}`;
 
-  const { collection } = JSON.parse(response as string) as { collection: UserLike[] };
-  logger.debug('User likes fetched', { count: collection.length });
+  while (nextHref && collection.length < limit) {
+    logger.debug('Fetching user likes page', { fetched: collection.length, limit });
 
-  return collection.map(({ track, created_at }) => ({
+    // Cursor pagination is inherently sequential — each page's `next_href` is in the previous response
+    // eslint-disable-next-line no-await-in-loop
+    const response = await webAgent(`${nextHref}&${auth}`);
+    const page = JSON.parse(response as string) as {
+      collection: UserLike[];
+      next_href?: string | null;
+    };
+
+    collection.push(...page.collection);
+    nextHref = page.next_href ?? null;
+
+    if (page.collection.length === 0) break;
+  }
+
+  logger.debug('User likes fetched', { count: Math.min(collection.length, limit) });
+
+  return collection.slice(0, limit).map(({ track, created_at }) => ({
     created_at,
     track: {
       ...track,

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,8 @@ export interface Track {
     transcodings: Array<{
       /** URL to fetch audio data */
       url: string;
+      /** True for Go+ preview/snippet transcodings; false for full streams */
+      snipped?: boolean;
       /** Format details */
       format: {
         /** Streaming protocol (e.g., 'progressive') */

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,8 +34,11 @@ export interface Track {
   id: number;
   /** Track title */
   title: string;
-  /** Track artist */
-  artist: string;
+  /** Uploading user (canonical fallback for the track artist) */
+  user: {
+    /** Username of the uploader */
+    username: string;
+  };
   /** URL to track artwork */
   artwork_url?: string;
   /** Media transcoding information */
@@ -53,12 +56,12 @@ export interface Track {
       };
     }>;
   };
-  /** Additional metadata from publisher */
+  /** Additional metadata from publisher (fields may be missing on individual tracks) */
   publisher_metadata?: {
     /** Artist name from publisher */
-    artist: string;
+    artist?: string;
     /** Release title from publisher */
-    release_title: string;
+    release_title?: string;
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,7 @@ export interface Track {
   id: number;
   /** Track title */
   title: string;
-  /** Uploading user (canonical fallback for the track artist) */
+  /** Uploading user */
   user: {
     /** Username of the uploader */
     username: string;
@@ -56,7 +56,7 @@ export interface Track {
       };
     }>;
   };
-  /** Additional metadata from publisher (fields may be missing on individual tracks) */
+  /** Additional metadata from publisher */
   publisher_metadata?: {
     /** Artist name from publisher */
     artist?: string;


### PR DESCRIPTION
Fixes #423.

## Root causes addressed

- **Pagination** — `getUserLikes` now walks SoundCloud's `next_href` cursor until `limit` is reached or pages are exhausted, instead of making a single request and silently capping at ~200.
- **Artist fallback** — `getTrackArtist` falls back to `track.user.username`. The previous `|| track.artist` was relying on a field that doesn't exist in SoundCloud's V2 API, producing 46 "Unknown Artist" tags in the reporter's run.
- **Snippet guard** — `downloadOne` throws on transcoding URLs containing `/preview/` (SoundCloud's Go+ snippet-only path), preventing silent partial downloads of 30-second clips labelled as full tracks.
- **Honest completion log** — `index.ts` reports `N downloaded, M failed, K verified` (parts included only when non-zero), replacing `Completed successfully: N tracks downloaded` which conflated attempts with successes.
- **Bounded concurrency** — `MAX_CONCURRENT_DOWNLOADS = 128` worker pool. Empirically the throughput peak before SC's edge starts queueing requests (verified across 10/20/50/100/128/200/256/300 with the live API).

## DRM-protected tracks (the 7 HTTP 404s in the original report)

These remain unrecoverable through the anonymous V2 API — they use `cbc-encrypted-hls`/`ctr-encrypted-hls` with Widevine + PlayReady, and the `audio/mpeg` endpoint returns 404. They now fail naturally with `HTTP 404: Not Found` and are counted truthfully in `failed` rather than masked by the misleading log.

## Verification

End-to-end against the live API:

\`\`\`
$ bun run src/cli.ts -u pink_ski_mask --limit 25
Completed: 24 downloaded, 1 failed
Failed to download "Nick Cave In": No full-length audio available
\`\`\`

- `tsc --noEmit` clean
- `eslint src` clean
- `bun run build` clean (dist emits)

## Test plan

- [ ] Run with a user that has >200 likes to verify multi-page pagination
- [ ] Verify ID3 `TPE1` on a previously-mistagged track is no longer "Unknown Artist"
- [ ] Verify a Go+ snippet track surfaces in the `failed` count with "No full-length audio available"
- [ ] Confirm the new completion log line matches the success/failure split exactly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added limited-concurrency downloads for more stable syncs
  * More explicit completion reporting with downloaded/failed counts

* **Bug Fixes**
  * Cursor-based pagination for retrieving likes
  * Artist fallback now uses uploader username when publisher data is absent
  * Prefer full MP3 transcodings and avoid preview/snipped audio where possible

* **Documentation**
  * API docs updated to reflect new parameters and type changes (including optional fields and snipped flag)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/realies/soundcloud-sync/pull/424)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->