### PR TITLE
ci(binaries): add windows-arm64 release target

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -23,6 +23,10 @@ jobs:
             arch: amd64
             target: bun-windows-x64
             output: soundcloud-sync-windows-amd64.exe
+          - os: windows-latest
+            arch: arm64
+            target: bun-windows-arm64
+            output: soundcloud-sync-windows-arm64.exe
           - os: macos-latest
             arch: amd64
             target: bun-darwin-x64


### PR DESCRIPTION
Adds the missing `windows-arm64` binary to the release matrix.

## Why this is now possible

Bun 1.3.0 (the version I checked initially) didn't support \`bun-windows-arm64\` as a cross-compile target — the workflow would have failed with \`Unsupported compile target: bun-windows-aarch64-vX.X.X\`. Bun 1.3.13 (latest) added the target.

The workflow already pulls \`bun-version: latest\`, so all that's needed is a new matrix entry. Cross-compile happens on the existing \`windows-latest\` (x64) runner — same pattern as the existing \`windows-amd64\` entry.

## Verification

Locally with Bun 1.3.13:
\`\`\`
$ bun build --compile --target bun-windows-arm64 --outfile /tmp/x.exe src/cli.ts
$ file /tmp/x.exe
/tmp/x.exe: PE32+ executable (console) Aarch64, for MS Windows
$ ls -la /tmp/x.exe
-rwxr-xr-x  ... 114518528 May 12 09:28 /tmp/x.exe   # 114 MB
\`\`\`

## Test plan
- [ ] Next release tag triggers the matrix and produces 6 binaries (linux x64/arm64, macos x64/arm64, windows x64 + **arm64**)
- [ ] Confirm \`soundcloud-sync-windows-arm64.exe\` shows up in the release assets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended platform support to include Windows ARM64 systems.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/realies/soundcloud-sync/pull/428)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->