### PR TITLE
ci(binaries): cross-compile windows-arm64 from ubuntu, not windows-x64

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -23,7 +23,10 @@ jobs:
             arch: amd64
             target: bun-windows-x64
             output: soundcloud-sync-windows-amd64.exe
-          - os: windows-latest
+          # Cross-compiled from Linux: Bun's Windows-x64 host can't fetch its own
+          # bun-windows-aarch64 helper (`Failed to extract executable`); Linux→Windows
+          # cross-compile works fine and mirrors the linux-arm64 pattern above.
+          - os: ubuntu-latest
             arch: arm64
             target: bun-windows-arm64
             output: soundcloud-sync-windows-arm64.exe


### PR DESCRIPTION
The v0.1.1 release-binaries run failed on the \`windows-latest-arm64\` job with:

\`\`\`
Failed to extract executable for 'bun-windows-aarch64-v1.3.13'. The download may be incomplete.
\`\`\`

Bun's Windows-x64 host can't fetch its own \`bun-windows-aarch64\` cross-compile helper. The same target builds fine from Linux or macOS (verified locally — 114MB PE32+ Aarch64 in <1s).

Switching the runner to \`ubuntu-latest\` mirrors the existing \`linux-arm64\` cross-compile pattern.

v0.1.1's missing \`soundcloud-sync-windows-arm64.exe\` was already uploaded manually to its release page; this commit ensures v0.1.2 and onward build it on CI without intervention.

## Test plan
- [ ] CI green
- [ ] Next release tag produces all 6 binaries via CI (no manual upload needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure for Windows binary compilation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/realies/soundcloud-sync/pull/430)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->