### PR TITLE
ci(binaries): disambiguate job names via matrix.target

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    name: Build ${{ matrix.os }}-${{ matrix.arch }}
+    name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Coderabbit nitpick on #430 that I missed.

After moving \`windows-arm64\` cross-compile to \`ubuntu-latest\` in the previous PR, two matrix jobs share \`os: ubuntu-latest\` + \`arch: arm64\` (\`linux-arm64\` and \`windows-arm64\`). The job name template was:

\`\`\`yaml
name: Build \${{ matrix.os }}-\${{ matrix.arch }}
\`\`\`

So both rendered as \`Build ubuntu-latest-arm64\` in the Actions UI — collision, makes triage ambiguous.

Switching to \`matrix.target\` (always unique: \`bun-linux-x64\`, \`bun-linux-arm64\`, \`bun-darwin-x64\`, \`bun-darwin-arm64\`, \`bun-windows-x64\`, \`bun-windows-arm64\`) gives each job an unambiguous display name like \`Build bun-windows-arm64\`.

## Test plan
- [ ] CI green
- [ ] Next release tag: confirm 6 distinct job names in the Actions UI (no two share the same label)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD build workflow configuration for improved clarity in build job display.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/realies/soundcloud-sync/pull/431)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->